### PR TITLE
Add build support for High Sierra+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,13 @@ headers := $(wildcard *.h)
 all: mobiledevice
 
 mobiledevice: $(sources) $(headers)
-	$(CC) -Wall -fobjc-arc -o mobiledevice -framework CoreFoundation -framework Cocoa -framework MobileDevice -F/System/Library/PrivateFrameworks $(DEFINES) $(sources)
+	./symlink_framework.sh
+	$(CC) -Wall -fobjc-arc -o mobiledevice -framework CoreFoundation -framework Cocoa -framework MobileDevice -FFrameworks $(DEFINES) $(sources)
 
 install: mobiledevice
 	install -d ${PREFIX}/bin
 	install mobiledevice ${PREFIX}/bin
 
 clean:
+	rm -rf Frameworks
 	rm -rf mobiledevice

--- a/symlink_framework.sh
+++ b/symlink_framework.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Apple bars linking against PrivateFrameworks on recent versions of
+# macOS, but we can work around this by symlinking the framework here
+# and pointing to this directory with `-F` in Makefile, which does work.
+MobileDevice="/System/Library/PrivateFrameworks/MobileDevice.framework"
+LocalFrameworks="$(pwd)/Frameworks"
+
+if [ -d "$LocalFrameworks" ]; then
+  echo "$LocalFrameworks seems to exist already; please delete it & try again"
+  exit 1
+fi
+
+mkdir -p "$LocalFrameworks"
+ln -sf "$MobileDevice" "$LocalFrameworks/MobileDevice.framework"
+
+if [ "$(readlink "$LocalFrameworks/MobileDevice.framework")" == "$MobileDevice" ]
+then
+  echo "Symlink creation successful"
+else
+  echo "Failed to create expected symlink"
+  exit 1
+fi


### PR DESCRIPTION
Fixes https://github.com/imkira/mobiledevice/issues/18.
Fixes https://github.com/imkira/mobiledevice/issues/16.

```
~> make
./symlink_framework.sh
Symlink creation successful
clang -Wall -fobjc-arc -o mobiledevice -framework CoreFoundation -framework Cocoa -framework MobileDevice -FFrameworks -DMOBILEDEVICE_CLI_VERSION=\"2.0.0\" -DMOBILEDEVICE_CLI_REVISION=\"59291109dfb9a4179896cd2844f35b36d60e93a6\" cli.m commands.m device.m get_app_prop.m get_bundle_id.m get_device_prop.m help.m install_app.m invalid_usage.m list_app_props.m list_apps.m list_device_props.m list_devices.m tunnel.m uninstall_app.m version.m
```

```
~> otool -L ./mobiledevice
./mobiledevice:
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1555.10.0)
	/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa (compatibility version 1.0.0, current version 23.0.0)
	/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1555.10.0)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.200.5)
```

Seems to work fine, based on cursory testing locally. `mobiledevice list_devices` and `mobiledevice list_device_props` both work as expected.
